### PR TITLE
update endpoint example to the new json api

### DIFF
--- a/examples/endpoint/endpoint.zig
+++ b/examples/endpoint/endpoint.zig
@@ -82,10 +82,9 @@ fn listUsers(self: *Self, r: zap.SimpleRequest) void {
 fn postUser(e: *zap.SimpleEndpoint, r: zap.SimpleRequest) void {
     const self = @fieldParentPtr(Self, "endpoint", e);
     if (r.body) |body| {
-        var stream = std.json.TokenStream.init(body);
-        var maybe_user: ?User = std.json.parse(User, &stream, .{ .allocator = self.alloc }) catch null;
+        var maybe_user: ?User = std.json.parseFromSlice(User, self.alloc, body, .{}) catch null;
         if (maybe_user) |u| {
-            defer std.json.parseFree(User, u, .{ .allocator = self.alloc });
+            defer std.json.parseFree(User, self.alloc, u);
             if (self.users.addByName(u.first_name, u.last_name)) |id| {
                 var jsonbuf: [128]u8 = undefined;
                 if (zap.stringifyBuf(&jsonbuf, .{ .status = "OK", .id = id }, .{})) |json| {
@@ -105,10 +104,9 @@ fn putUser(e: *zap.SimpleEndpoint, r: zap.SimpleRequest) void {
         if (self.userIdFromPath(path)) |id| {
             if (self.users.get(id)) |_| {
                 if (r.body) |body| {
-                    var stream = std.json.TokenStream.init(body);
-                    var maybe_user: ?User = std.json.parse(User, &stream, .{ .allocator = self.alloc }) catch null;
+                    var maybe_user: ?User = std.json.parseFromSlice(User, self.alloc, body, .{}) catch null;
                     if (maybe_user) |u| {
-                        defer std.json.parseFree(User, u, .{ .allocator = self.alloc });
+                        defer std.json.parseFree(User, self.alloc, u);
                         var jsonbuf: [128]u8 = undefined;
                         if (self.users.update(id, u.first_name, u.last_name)) {
                             if (zap.stringifyBuf(&jsonbuf, .{ .status = "OK", .id = id }, .{})) |json| {


### PR DESCRIPTION
zig 0.11.0-dev.3203+7cf2cbb33 has updated the json api. I've updated to use the new parseFromSlice call which basically does the init and deinit of the json.Scanner so we don't have to do it as we had to for json.TokenStream.
