### PR TITLE
Add C# AOT version for comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ tmp/
 **/target/*
 **/__pycache__/*
 wrk/go/main
+wrk/csharp/bin/
+wrk/csharp/obj/
+wrk/csharp/out/
 scratch
 **/.mypy_cache/*
 docs/
+.DS_Store
+.vs/

--- a/wrk/csharp/Program.cs
+++ b/wrk/csharp/Program.cs
@@ -1,0 +1,8 @@
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.ClearProviders();
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello from C#");
+
+app.Run();

--- a/wrk/csharp/Properties/launchSettings.json
+++ b/wrk/csharp/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5026",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/wrk/csharp/csharp.csproj
+++ b/wrk/csharp/csharp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+</Project>

--- a/wrk/measure.sh
+++ b/wrk/measure.sh
@@ -58,6 +58,13 @@ if [ "$SUBJECT" = "axum" ] ; then
     URL=http://127.0.0.1:3000
 fi
 
+if [ "$SUBJECT" = "csharp" ] ; then
+    cd wrk/csharp && dotnet publish csharp.csproj -o ./out
+    ./out/csharp --urls "http://127.0.0.1:5026" &
+    PID=$!
+    URL=http://127.0.0.1:5026
+fi
+
 sleep 1
 echo "========================================================================"
 echo "                          $SUBJECT"


### PR DESCRIPTION
I was curious about C# AOT using [dotnet 8 preview](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).  The numbers are about the same for `C#` `Go` `Rust (Axum)`. I'm wondering if there is something stopping wrk from performing more requests. I'm using a M1 Pro mac. 

I couldn't build `Zig` from HEAD 😢

<img width="1500" alt="image" src="https://github.com/zigzap/zap/assets/32940986/c55da8ca-17b0-455e-b4ea-1df909930379">
