### PR TITLE
Revert Context changes in middleware_with_endpoint by fixing middlewa…

### DIFF
--- a/examples/middleware_with_endpoint/middleware_with_endpoint.zig
+++ b/examples/middleware_with_endpoint/middleware_with_endpoint.zig
@@ -20,10 +20,10 @@ const SharedAllocator = struct {
 };
 
 // create a combined context struct
-const Context = struct {
-    user: ?UserMiddleWare.User = null,
-    session: ?SessionMiddleWare.Session = null,
-};
+const Context = zap.Middleware.MixContexts(.{
+    .{ .name = "?user", .type = UserMiddleWare.User },
+    .{ .name = "?session", .type = SessionMiddleWare.Session },
+});
 
 // we create a Handler type based on our Context
 const Handler = zap.Middleware.Handler(Context);

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -22,7 +22,7 @@ pub fn MixContexts(comptime context_tuple: anytype) type {
         fields[i] = .{
             .name = fieldName,
             .type = fieldType,
-            .default_value = if (isOptional) &null else null,
+            .default_value = if (isOptional) &@as(fieldType, null) else null,
             .is_comptime = false,
             .alignment = 0,
         };


### PR DESCRIPTION
…re MixContexts

I found the problem in the original MixContexts code in middleware.
When asked around, I found out that you need to use &@as(fieldType, null) instead of &null for default_value.