### PR TITLE
Mustache doc comments

### DIFF
--- a/src/mustache.zig
+++ b/src/mustache.zig
@@ -78,7 +78,7 @@ pub const Mustache = struct {
         const ret = fiobj_mustache_new(args);
         switch (err) {
             0 => return Self{
-                .handler = ret.?,
+                .handle = ret.?,
             },
             1 => return Error.MUSTACHE_ERR_TOO_DEEP,
             2 => return Error.MUSTACHE_ERR_CLOSURE_MISMATCH,


### PR DESCRIPTION
- Updated `Mustache.fiobjectify` to be private
- Updated docstrings on `Mustache.build`
- Renamed `Mustache.handler` -> `Mustache.handle`
- Added docstrings for `Mustache.fiobjectify` and `Mustache.handle`
- Removed `Mustache.status`