### PR TITLE
Use std.http.Method for Request.method

### DIFF
--- a/examples/hello2/hello2.zig
+++ b/examples/hello2/hello2.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const zap = @import("zap");
 
 fn on_request(r: zap.Request) void {
-    const m = r.method orelse "";
+    const m = r.method_str orelse "";
     const p = r.path orelse "/";
     const qm = if (r.query) |_| "?" else "";
     const qq = r.query orelse "";

--- a/examples/hello_json/hello_json.zig
+++ b/examples/hello_json/hello_json.zig
@@ -7,8 +7,7 @@ const User = struct {
 };
 
 fn on_request(r: zap.Request) void {
-    if (!std.mem.eql(u8, r.method.?, "GET"))
-        return;
+    if (r.method == null or r.method.? == .GET) return;
 
     // /user/n
     if (r.path) |the_path| {

--- a/examples/hello_json/hello_json.zig
+++ b/examples/hello_json/hello_json.zig
@@ -7,7 +7,7 @@ const User = struct {
 };
 
 fn on_request(r: zap.Request) void {
-    if (r.method == null or r.method.? == .GET) return;
+    if (r.method.? != .GET) return;
 
     // /user/n
     if (r.path) |the_path| {

--- a/src/endpoint.zig
+++ b/src/endpoint.zig
@@ -60,18 +60,15 @@ fn nop(self: *Endpoint, r: Request) void {
 
 /// The global request handler for this Endpoint, called by the listener.
 pub fn onRequest(self: *Endpoint, r: zap.Request) void {
-    const Method = std.http.Method;
-    return if (r.method) |m| {
-        switch (m) {
-            Method.GET => self.settings.get.?(self, r),
-            Method.POST => self.settings.post.?(self, r),
-            Method.PUT => self.settings.put.?(self, r),
-            Method.DELETE => self.settings.delete.?(self, r),
-            Method.PATCH => self.settings.patch.?(self, r),
-            Method.OPTIONS => self.settings.options.?(self, r),
-            else => return,
-        }
-    };
+    switch (r.method) {
+        .GET => self.settings.get.?(self, r),
+        .POST => self.settings.post.?(self, r),
+        .PUT => self.settings.put.?(self, r),
+        .DELETE => self.settings.delete.?(self, r),
+        .PATCH => self.settings.patch.?(self, r),
+        .OPTIONS => self.settings.options.?(self, r),
+        else => return,
+    }
 }
 
 /// Wrap an endpoint with an Authenticator -> new Endpoint of type Endpoint

--- a/src/endpoint.zig
+++ b/src/endpoint.zig
@@ -60,20 +60,18 @@ fn nop(self: *Endpoint, r: Request) void {
 
 /// The global request handler for this Endpoint, called by the listener.
 pub fn onRequest(self: *Endpoint, r: zap.Request) void {
-    if (r.method) |m| {
-        if (std.mem.eql(u8, m, "GET"))
-            return self.settings.get.?(self, r);
-        if (std.mem.eql(u8, m, "POST"))
-            return self.settings.post.?(self, r);
-        if (std.mem.eql(u8, m, "PUT"))
-            return self.settings.put.?(self, r);
-        if (std.mem.eql(u8, m, "DELETE"))
-            return self.settings.delete.?(self, r);
-        if (std.mem.eql(u8, m, "PATCH"))
-            return self.settings.patch.?(self, r);
-        if (std.mem.eql(u8, m, "OPTIONS"))
-            return self.settings.options.?(self, r);
-    }
+    const Method = std.http.Method;
+    return if (r.method) |m| {
+        switch (m) {
+            Method.GET => self.settings.get.?(self, r),
+            Method.POST => self.settings.post.?(self, r),
+            Method.PUT => self.settings.put.?(self, r),
+            Method.DELETE => self.settings.delete.?(self, r),
+            Method.PATCH => self.settings.patch.?(self, r),
+            Method.OPTIONS => self.settings.options.?(self, r),
+            else => return,
+        }
+    };
 }
 
 /// Wrap an endpoint with an Authenticator -> new Endpoint of type Endpoint

--- a/src/http.zig
+++ b/src/http.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 /// HTTP Status codes according to `rfc7231`
 /// https://tools.ietf.org/html/rfc7231#section-6
 /// (taken from https://github.com/Luukdegram/apple_pie/blob/master/src/response.zig)
@@ -105,3 +107,32 @@ pub const StatusCode = enum(u16) {
         };
     }
 };
+
+pub const Method = enum {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    PATCH,
+    OPTIONS,
+    UNKNOWN,
+};
+pub fn methodToEnum(method: ?[]const u8) Method {
+    {
+        if (method) |m| {
+            if (std.mem.eql(u8, m, "GET"))
+                return Method.GET;
+            if (std.mem.eql(u8, m, "POST"))
+                return Method.POST;
+            if (std.mem.eql(u8, m, "PUT"))
+                return Method.PUT;
+            if (std.mem.eql(u8, m, "DELETE"))
+                return Method.DELETE;
+            if (std.mem.eql(u8, m, "PATCH"))
+                return Method.PATCH;
+            if (std.mem.eql(u8, m, "OPTIONS"))
+                return Method.OPTIONS;
+        }
+        return Method.UNKNOWN;
+    }
+}

--- a/src/request.zig
+++ b/src/request.zig
@@ -266,7 +266,8 @@ pub const CookieArgs = struct {
 path: ?[]const u8,
 query: ?[]const u8,
 body: ?[]const u8,
-method: ?[]const u8,
+method: ?std.http.Method,
+method_str: ?[]const u8,
 h: [*c]fio.http_s,
 
 /// NEVER touch this field!!!!

--- a/src/request.zig
+++ b/src/request.zig
@@ -266,7 +266,7 @@ pub const CookieArgs = struct {
 path: ?[]const u8,
 query: ?[]const u8,
 body: ?[]const u8,
-method: ?std.http.Method,
+method: http.Method,
 method_str: ?[]const u8,
 h: [*c]fio.http_s,
 

--- a/src/zap.zig
+++ b/src/zap.zig
@@ -184,6 +184,27 @@ pub const HttpListenerSettings = struct {
     tls: ?Tls = null,
 };
 
+fn methodToEnum(method: ?[]const u8) ?std.http.Method {
+    const Method = std.http.Method;
+    {
+        if (method) |m| {
+            if (std.mem.eql(u8, m, "GET"))
+                return Method.GET;
+            if (std.mem.eql(u8, m, "POST"))
+                return Method.POST;
+            if (std.mem.eql(u8, m, "PUT"))
+                return Method.PUT;
+            if (std.mem.eql(u8, m, "DELETE"))
+                return Method.DELETE;
+            if (std.mem.eql(u8, m, "PATCH"))
+                return Method.PATCH;
+            if (std.mem.eql(u8, m, "OPTIONS"))
+                return Method.OPTIONS;
+        }
+        return null;
+    }
+}
+
 /// Http listener
 pub const HttpListener = struct {
     settings: HttpListenerSettings,
@@ -207,7 +228,8 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = util.fio2str(r.*.method),
+                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,
                 ._user_context = undefined,
@@ -233,7 +255,8 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = util.fio2str(r.*.method),
+                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,
                 ._user_context = undefined,
@@ -254,7 +277,8 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = util.fio2str(r.*.method),
+                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,
                 ._user_context = undefined,

--- a/src/zap.zig
+++ b/src/zap.zig
@@ -184,27 +184,6 @@ pub const HttpListenerSettings = struct {
     tls: ?Tls = null,
 };
 
-fn methodToEnum(method: ?[]const u8) ?std.http.Method {
-    const Method = std.http.Method;
-    {
-        if (method) |m| {
-            if (std.mem.eql(u8, m, "GET"))
-                return Method.GET;
-            if (std.mem.eql(u8, m, "POST"))
-                return Method.POST;
-            if (std.mem.eql(u8, m, "PUT"))
-                return Method.PUT;
-            if (std.mem.eql(u8, m, "DELETE"))
-                return Method.DELETE;
-            if (std.mem.eql(u8, m, "PATCH"))
-                return Method.PATCH;
-            if (std.mem.eql(u8, m, "OPTIONS"))
-                return Method.OPTIONS;
-        }
-        return null;
-    }
-}
-
 /// Http listener
 pub const HttpListener = struct {
     settings: HttpListenerSettings,
@@ -228,7 +207,7 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method = http.methodToEnum(util.fio2str(r.*.method)),
                 .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,
@@ -255,7 +234,7 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method = http.methodToEnum(util.fio2str(r.*.method)),
                 .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,
@@ -277,7 +256,7 @@ pub const HttpListener = struct {
                 .path = util.fio2str(r.*.path),
                 .query = util.fio2str(r.*.query),
                 .body = util.fio2str(r.*.body),
-                .method = methodToEnum(util.fio2str(r.*.method)),
+                .method = http.methodToEnum(util.fio2str(r.*.method)),
                 .method_str = util.fio2str(r.*.method),
                 .h = r,
                 ._is_finished_request_global = false,


### PR DESCRIPTION
This PR does the following:

- `Request.method` becomes an `std.http.Method enum` so developers can use switch statements and other better syntax on it
- `Request.method_str` is the original string representation of the http method

Why both? 

Quality of life. Since there is no easy and concise way of printing Enum in Zig, one will make request easier to compare and the other will be easier to print. Examples also have been updated accordingly. This decision was made based on my personal need without approval of anyone, so please do feel free to reject this PR, request changes, or make criticisms if this change doesn't feel fit for the project.

What happens if the HTTP method is none of the one listed? 

Well, it shouldn't happen, because I did see a part of Zap's (or facil's I can't remember) code telling the client what http methods are acceptable. If exception does happen (edge cases matter - zig zon), `Request.method` will be null and `Request.method_str` stays the same. The Method Enum defines a set of "normal circumstances", and a null value represents exception, which I think is a good abstraction of what is to be done with http methods.

This has been tested as part of my own project, and everything is working as intended. A [test package](https://github.com/Chiissu/zap/releases/tag/v0.6.0-alpha) is available, use at your own risk.

Closes #67 

<img src="https://github.com/Avdan-OS/Compositor/assets/51555391/d0379882-f2dc-42e1-962f-b3f122db656f" alt="vibe" width="60"/>