### PR TITLE
Provide Windows error message

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,8 +3,10 @@ const build_facilio = @import("facil.io/build.zig").build_facilio;
 
 pub fn build(b: *std.build.Builder) !void {
     const target = b.standardTargetOptions(.{});
-    if (target.getOsTag() == .windows)
-        @panic("\nCurrently, Facil.io and Zap are not compatible with Windows. Consider using Linux or Windows Subsystem for Linux (WSL) instead.\nFor more information, please see:\n- https://github.com/zigzap/zap#most-faq\n- https://facil.io/#forking-contributing-and-all-that-jazz\n");
+    if (target.getOsTag() == .windows) {
+        std.log.err("\x1b[31mPlatform Not Supported\x1b[0m\nCurrently, Facil.io and Zap are not compatible with Windows. Consider using Linux or Windows Subsystem for Linux (WSL) instead.\nFor more information, please see:\n- https://github.com/zigzap/zap#most-faq\n- https://facil.io/#forking-contributing-and-all-that-jazz\n", .{});
+        std.os.exit(1);
+    }
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,8 @@ const build_facilio = @import("facil.io/build.zig").build_facilio;
 
 pub fn build(b: *std.build.Builder) !void {
     const target = b.standardTargetOptions(.{});
+    if (target.getOsTag() == .windows)
+        @panic("\nCurrently, Facil.io and Zap are not compatible with Windows. Consider using Linux or Windows Subsystem for Linux (WSL) instead.\nFor more information, please see:\n- https://github.com/zigzap/zap#most-faq\n- https://facil.io/#forking-contributing-and-all-that-jazz\n");
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});


### PR DESCRIPTION
Yes, it is already in README. I just thought it would be nice if the build system explicitly fails Windows builds.

<img width="942" src="https://github.com/zigzap/zap/assets/51555391/121f5011-dc51-43d8-8fbc-6817fbb59e1a">

Test package available [[here](https://github.com/Chiissu/zap/releases/tag/v0.6.0-alpha3)].

Just 2 LOC, thanks to Zig's beautiful build system.

Just wanna mention #74 

<img src="https://github.com/Avdan-OS/Compositor/assets/51555391/d0379882-f2dc-42e1-962f-b3f122db656f" alt="vibe" width="60"/>