### PR TITLE
fixed unneeded optional unwrap in hello_json

### DIFF
--- a/examples/hello_json/hello_json.zig
+++ b/examples/hello_json/hello_json.zig
@@ -7,7 +7,7 @@ const User = struct {
 };
 
 fn on_request(r: zap.Request) void {
-    if (r.method.? != .GET) return;
+    if (r.method != .GET) return;
 
     // /user/n
     if (r.path) |the_path| {


### PR DESCRIPTION
hello_json example failed to compile because of optional unwrap. Fixed by removing the ".?"