### PR TITLE
add http.zig to benchmarks

### DIFF
--- a/wrk/measure.sh
+++ b/wrk/measure.sh
@@ -28,6 +28,15 @@ if [ "$SUBJECT" = "zigstd" ] ; then
     URL=http://127.0.0.1:3000
 fi
 
+if [ "$SUBJECT" = "zighttpz" ] ; then
+    pushd wrk/zighttpz
+        zig build -Doptimize=ReleaseFast > /dev/null
+        $TSK_SRV ../../zig-out/bin/wrk &
+        PID=$!
+        URL=http://127.0.0.1:3000
+    popd
+fi
+
 if [ "$SUBJECT" = "go" ] ; then
     cd wrk/go && go build main.go 
     $TSK_SRV ./main &

--- a/wrk/zighttpz/build.zig
+++ b/wrk/zighttpz/build.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const httpz_dep = b.dependency("httpz", .{ .target = target, .optimize = optimize });
+
+    // setup executable
+    const exe = b.addExecutable(.{
+        .name = "wrk_zighttpz",
+        .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("httpz", httpz_dep.module("httpz"));
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+}

--- a/wrk/zighttpz/build.zig.zon
+++ b/wrk/zighttpz/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "http.zig-test",
+    .version = "0.0.0",
+    .paths = .{""},
+    .dependencies = .{
+        .httpz = .{
+            .url = "https://github.com/karlseguin/http.zig/archive/ec59a3daccd5145601a18786ef033f4ff2392520.tar.gz",
+            .hash = "12209ba122606b92c7dfb0a7dfb9da5520ffa5df007b976774e91d01b2040b25fae4"
+        },
+    },
+}

--- a/wrk/zighttpz/build.zig.zon
+++ b/wrk/zighttpz/build.zig.zon
@@ -4,8 +4,8 @@
     .paths = .{""},
     .dependencies = .{
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/ec59a3daccd5145601a18786ef033f4ff2392520.tar.gz",
-            .hash = "12209ba122606b92c7dfb0a7dfb9da5520ffa5df007b976774e91d01b2040b25fae4"
+            .url = "https://github.com/karlseguin/http.zig/archive/zig-0.12.tar.gz",
+            .hash = "12209b7426293ebe5075b930ae6029c009bfb6deb7ff92b9d69e28463abd14ad03da"
         },
     },
 }

--- a/wrk/zighttpz/main.zig
+++ b/wrk/zighttpz/main.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{
+        .thread_safe = true,
+    }){};
+    const allocator = gpa.allocator();
+
+    var server = try httpz.Server().init(allocator, .{
+        .port = 3000,
+        .address = "127.0.0.1",
+    });
+    defer server.deinit();
+    var router = server.router();
+
+    router.get("/", index);
+    try server.listen();
+}
+
+fn index(_: *httpz.Request, res: *httpz.Response) !void {
+    res.body = "HI FROM ZIG-HTTPZ";
+}


### PR DESCRIPTION
Hello,
This adds http.zig to the benchmarks. The library has undergone a number of changes and, in my measurements, comes very close to Zap. I think this is worth highlighting as most pure Zig implementations are very slow.

(I see that there's already an http.zig branch, but it's quite old and can be deleted)