### PR TITLE
fix: use error return trace in senderror

### DIFF
--- a/examples/senderror/senderror.zig
+++ b/examples/senderror/senderror.zig
@@ -7,7 +7,7 @@ fn MAKE_MEGA_ERROR() !void {
 
 fn MY_REQUEST_HANDLER(r: zap.Request) void {
     MAKE_MEGA_ERROR() catch |err| {
-        r.sendError(err, 505);
+        r.sendError(err, if (@errorReturnTrace()) |t| t.* else null, 505);
     };
 }
 


### PR DESCRIPTION
This should produce more usable error messages. The error messages before this were pointing at zap runtime functions, instead of at the code that produced the error.

Note that this is a breaking change, as I modified the `sendError` to take StackTrace argument. This is in part because I am unsure if `@errorReturnTrace` will be overwritten by the other function calls that can return an error, so I take the StackTrace by value.

Before, the stack traces looked like this:

```
ERROR: error.NoSeries

/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/src/request.zig:344:41: 0x2f6217 in _internal_sendError (raptor)
    try std.debug.writeCurrentStackTrace(writer, debugInfo, ttyConfig, null);
                                        ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/src/request.zig:324:33: 0x2abf2f in sendError (raptor)
    if (self._internal_sendError(err, errorcode_num)) {
                                ^
/home/geemili/wasatch-photonics/src/wpgratingtools/src/RaptorEndpoint.zig:72:20: 0x2977a0 in get (raptor)
        r.sendError(e, 505);
                   ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/src/endpoint.zig:64:36: 0x2e8542 in onRequest (raptor)
        .GET => self.settings.get.?(self, r),
                                   ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/src/endpoint.zig:320:32: 0x29ce90 in onRequest (raptor)
                    e.onRequest(r);
                               ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/src/zap.zig:224:27: 0x29855e in theOneAndOnlyRequestCallBack (raptor)
                on_request(req);
                          ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http_internal.c:53:3: 0x793c9b in http_on_request_handler______internal (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http_internal.c)
  settings->on_request(h);
  ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c:553:3: 0x7a2151 in http1_on_request (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c)
  http_on_request_handler______internal(&http1_pr2handle(p), p->p.settings);
  ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/parsers/http1_parser.h:859:9: 0x7a174a in http1_parse (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c)
    if (((parser->state.reserved & HTTP1_P_FLAG_RESPONSE)
        ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c:689:9: 0x7a1103 in http1_consume_data (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c)
    i = http1_parse(&p->parser, p->buf + (org_len - p->buf_len), p->buf_len);
        ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c:735:3: 0x7a1059 in http1_on_data (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/http/http1.c)
  http1_consume_data(uuid, p);
  ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c:2213:3: 0x75f845 in deferred_on_data (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c)
  pr->on_data((intptr_t)uuid, pr);
  ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c:1011:3: 0x75ea5a in fio_defer_perform_single_task_for_queue (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c)
  task.func(task.arg1, task.arg2);
  ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c:1049:10: 0x75e9e4 in fio_defer_perform (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c)
         fio_defer_perform_single_task_for_queue(&task_queue_normal) == 0)
         ^
/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c:1089:5: 0x7851b5 in fio_defer_cycle (/home/geemili/.cache/zig/p/1220a5a1e6b18fa384d8a98e5d5a25720ddadbcfed01da2e4ca55c7cfb3dc1caa62a/facil.io/lib/facil/fio.c)
    fio_defer_perform();
    ^
???:?:?: 0x7f8fee3e60e3 in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7f8fee3e60e3` was not available, trace may be incomplete
```

After this change, they should look like this:

```
ERROR: error.MEGA_ERROR

/home/geemili/src/3_resources/zap/examples/senderror/senderror.zig:5:5: 0x23ab28 in MAKE_MEGA_ERROR (senderror)
    return error.MEGA_ERROR;
    ^
```