### PR TITLE
feat: add getHeaderCommon

### DIFF
--- a/src/request.zig
+++ b/src/request.zig
@@ -441,41 +441,58 @@ pub fn getHeader(self: *const Self, name: []const u8) ?[]const u8 {
 
 pub const HttpHeaderCommon = enum(usize) {
     /// Represents the HTTP Header "Accept".
-    accept = fio.HTTP_HEADER_ACCEPT,
+    accept,
     /// Represents the HTTP Header "Cache-Control".
-    cache_control = fio.HTTP_HEADER_CACHE_CONTROL,
+    cache_control,
     /// Represents the HTTP Header "Connection".
-    connection = fio.HTTP_HEADER_CONNECTION,
+    connection,
     /// Represents the HTTP Header "Content-Encoding".
-    content_encoding = fio.HTTP_HEADER_CONTENT_ENCODING,
+    content_encoding,
     /// Represents the HTTP Header "Content-Length".
-    content_length = fio.HTTP_HEADER_CONTENT_LENGTH,
+    content_length,
     /// Represents the HTTP Header "Content-Range".
-    content_range = fio.HTTP_HEADER_CONTENT_RANGE,
+    content_range,
     /// Represents the HTTP Header "Content-Type".
-    content_type = fio.HTTP_HEADER_CONTENT_TYPE,
+    content_type,
     /// Represents the HTTP Header "Cookie".
-    cookie = fio.HTTP_HEADER_COOKIE,
+    cookie,
     /// Represents the HTTP Header "Date".
-    date = fio.HTTP_HEADER_DATE,
+    date,
     /// Represents the HTTP Header "Etag".
-    etag = fio.HTTP_HEADER_ETAG,
+    etag,
     /// Represents the HTTP Header "Host".
-    host = fio.HTTP_HEADER_HOST,
+    host,
     /// Represents the HTTP Header "Last-Modified".
-    last_modifed = fio.HTTP_HEADER_LAST_MODIFIED,
+    last_modifed,
     /// Represents the HTTP Header "Origin".
-    origin = fio.HTTP_HEADER_ORIGIN,
+    origin,
     /// Represents the HTTP Header "Set-Cookie".
-    set_cookie = fio.HTTP_HEADER_SET_COOKIE,
+    set_cookie,
     /// Represents the HTTP Header "Upgrade".
-    upgrade = fio.HTTP_HEADER_UPGRADE,
+    upgrade,
 };
 
 /// Returns the header value of a given common header key. Returned memory
 /// should not be freed.
 pub fn getHeaderCommon(self: *const Self, which: HttpHeaderCommon) ?[]const u8 {
-    const fiobj = zap.fio.fiobj_hash_get(self.h.*.headers, @intFromEnum(which));
+    const field = switch (which) {
+        .accept => fio.HTTP_HEADER_ACCEPT,
+        .cache_control => fio.HTTP_HEADER_CACHE_CONTROL,
+        .connection => fio.HTTP_HEADER_CONNECTION,
+        .content_encoding => fio.HTTP_HEADER_CONTENT_ENCODING,
+        .content_length => fio.HTTP_HEADER_CONTENT_LENGTH,
+        .content_range => fio.HTTP_HEADER_CONTENT_RANGE,
+        .content_type => fio.HTTP_HEADER_CONTENT_TYPE,
+        .cookie => fio.HTTP_HEADER_COOKIE,
+        .date => fio.HTTP_HEADER_DATE,
+        .etag => fio.HTTP_HEADER_ETAG,
+        .host => fio.HTTP_HEADER_HOST,
+        .last_modified => fio.HTTP_HEADER_LAST_MODIFIED,
+        .origin => fio.HTTP_HEADER_ORIGIN,
+        .set_cookie => fio.HTTP_HEADER_SET_COOKIE,
+        .upgrade => fio.HTTP_HEADER_UPGRADE,
+    };
+    const fiobj = zap.fio.fiobj_hash_get(self.h.*.headers, field);
     return zap.fio2str(fiobj);
 }
 

--- a/src/request.zig
+++ b/src/request.zig
@@ -439,6 +439,46 @@ pub fn getHeader(self: *const Self, name: []const u8) ?[]const u8 {
     return util.fio2str(fio.fiobj_hash_get(self.h.*.headers, hname));
 }
 
+pub const HttpHeaderCommon = enum(usize) {
+    /// Represents the HTTP Header "Accept".
+    accept = fio.HTTP_HEADER_ACCEPT,
+    /// Represents the HTTP Header "Cache-Control".
+    cache_control = fio.HTTP_HEADER_CACHE_CONTROL,
+    /// Represents the HTTP Header "Connection".
+    connection = fio.HTTP_HEADER_CONNECTION,
+    /// Represents the HTTP Header "Content-Encoding".
+    content_encoding = fio.HTTP_HEADER_CONTENT_ENCODING,
+    /// Represents the HTTP Header "Content-Length".
+    content_length = fio.HTTP_HEADER_CONTENT_LENGTH,
+    /// Represents the HTTP Header "Content-Range".
+    content_range = fio.HTTP_HEADER_CONTENT_RANGE,
+    /// Represents the HTTP Header "Content-Type".
+    content_type = fio.HTTP_HEADER_CONTENT_TYPE,
+    /// Represents the HTTP Header "Cookie".
+    cookie = fio.HTTP_HEADER_COOKIE,
+    /// Represents the HTTP Header "Date".
+    date = fio.HTTP_HEADER_DATE,
+    /// Represents the HTTP Header "Etag".
+    etag = fio.HTTP_HEADER_ETAG,
+    /// Represents the HTTP Header "Host".
+    host = fio.HTTP_HEADER_HOST,
+    /// Represents the HTTP Header "Last-Modified".
+    last_modifed = fio.HTTP_HEADER_LAST_MODIFIED,
+    /// Represents the HTTP Header "Origin".
+    origin = fio.HTTP_HEADER_ORIGIN,
+    /// Represents the HTTP Header "Set-Cookie".
+    set_cookie = fio.HTTP_HEADER_SET_COOKIE,
+    /// Represents the HTTP Header "Upgrade".
+    upgrade = fio.HTTP_HEADER_UPGRADE,
+};
+
+/// Returns the header value of a given common header key. Returned memory
+/// should not be freed.
+pub fn getHeaderCommon(self: *const Self, which: HttpHeaderCommon) ?[]const u8 {
+    const fiobj = zap.fio.fiobj_hash_get(self.h.*.headers, @intFromEnum(which));
+    return zap.fio2str(fiobj);
+}
+
 /// Set header.
 pub fn setHeader(self: *const Self, name: []const u8, value: []const u8) HttpError!void {
     const hname: fio.fio_str_info_s = .{


### PR DESCRIPTION
Adds a function to get one of the common headers that facil.io pre-allocates space for. For context, I was trying to get the "Accept" field and `request.getHeader("Accept")` didn't work. It's easy enough to work around, but I think having `getHeaderCommon` would be a slightly nicer interface.