### PR TITLE
update http.zig to rfc9110

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -1,29 +1,39 @@
 const std = @import("std");
 
-/// HTTP Status codes according to `rfc7231`
-/// https://tools.ietf.org/html/rfc7231#section-6
-/// (taken from https://github.com/Luukdegram/apple_pie/blob/master/src/response.zig)
+/// HTTP Status codes according to `rfc9110`
+/// https://datatracker.ietf.org/doc/html/rfc9110#name-status-codes
+/// (modified from https://github.com/Luukdegram/apple_pie/blob/master/src/response.zig)
 pub const StatusCode = enum(u16) {
-    // Informational 1xx
+    // Information responses
     @"continue" = 100,
-    // Successful 2xx
     switching_protocols = 101,
+    processing = 102, // (WebDAV)
+    early_hints = 103,
+
+    // Successful responses
     ok = 200,
     created = 201,
     accepted = 202,
     non_authoritative_information = 203,
     no_content = 204,
     reset_content = 205,
-    // redirections 3xx
     partial_content = 206,
+    multi_status = 207, // (WebDAV)
+    already_reported = 208, // (WebDAV)
+    im_used = 226, // (HTTP Delta encoding)
+
+    // Redirection messages
     multiple_choices = 300,
     moved_permanently = 301,
     found = 302,
     see_other = 303,
     not_modified = 304,
     use_proxy = 305,
+    unused = 306,
     temporary_redirect = 307,
-    // client errors 4xx
+    permanent_redirect = 308,
+
+    // Client error responses
     bad_request = 400,
     unauthorized = 401,
     payment_required = 402,
@@ -37,23 +47,35 @@ pub const StatusCode = enum(u16) {
     gone = 410,
     length_required = 411,
     precondition_failed = 412,
-    request_entity_too_large = 413,
-    request_uri_too_long = 414,
-    unsupported_mediatype = 415,
-    requested_range_not_satisfiable = 416,
+    payload_too_large = 413,
+    uri_too_long = 414,
+    unsupported_media_type = 415,
+    range_not_satisfiable = 416,
     expectation_failed = 417,
-    /// teapot is an extension status code and not required for clients to support
-    teapot = 418,
+    im_a_teapot = 418,
+    misdirected_request = 421,
+    unprocessable_content = 422, // (WebDAV)
+    locked = 423, // (WebDAV)
+    failed_dependency = 424, // (WebDAV)
+    too_early = 425,
     upgrade_required = 426,
-    /// extra status code according to `https://tools.ietf.org/html/rfc6585#section-5`
+    precondition_required = 428,
+    too_many_requests = 429,
     request_header_fields_too_large = 431,
-    // server errors 5xx
+    unavailable_for_legal_reasons = 451,
+
+    // Server error responses
     internal_server_error = 500,
     not_implemented = 501,
     bad_gateway = 502,
     service_unavailable = 503,
     gateway_timeout = 504,
     http_version_not_supported = 505,
+    variant_also_negotiates = 506,
+    insufficient_storage = 507, // (WebDAV)
+    loop_detected = 508, // (WebDAV)
+    not_extended = 510,
+    network_authentication_required = 511,
     _,
 
     /// Returns the string value of a `StatusCode`


### PR DESCRIPTION
using MDN as a reference.

I added new status codes as described by [rfc9110][1] and [MDN][2]. Some were renamed since rfc7231, so I renamed them. It feels like good practice to keep up with spec, huh?

[1]: https://datatracker.ietf.org/doc/html/rfc9110#name-status-codes
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status