### PR TITLE
Fix docserver, Wrap http_mimetype_register and http_mimetype_clear

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -247,6 +247,7 @@ pub fn build(b: *std.Build) !void {
 
     const docserver_run_step = b.step("run-docserver", "run the docserver");
     const docserver_run = b.addRunArtifact(docserver_exe);
+    docserver_run.addPrefixedDirectoryArg("--docs=", docs_obj.getEmittedBinDirectory());
     docserver_run_step.dependOn(&docserver_run.step);
     docserver_run_step.dependOn(docserver_step);
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const fio = @import("fio.zig");
 
 /// HTTP Status codes according to `rfc7231`
 /// https://tools.ietf.org/html/rfc7231#section-6
@@ -125,4 +126,21 @@ pub fn methodToEnum(method: ?[]const u8) Method {
         }
         return Method.UNKNOWN;
     }
+}
+
+/// Registers a new mimetype to be used for files ending with the given extension.
+pub fn mimetypeRegister(file_extension: []const u8, mime_type_str: []const u8) void {
+    // NOTE: facil.io is expecting a non-const pointer to u8 values, but it does not
+    // not appear to actually modify the value.  Here we do a const cast so
+    // that it is easy to pass static strings to http_mimetype_register without
+    // needing to allocate a buffer on the heap.
+    const extension = @constCast(file_extension);
+    const mimetype = fio.fiobj_str_new(mime_type_str.ptr, mime_type_str.len);
+
+    fio.http_mimetype_register(extension.ptr, extension.len, mimetype);
+}
+
+/// Clears the Mime-Type registry (it will be empty after this call).
+pub fn mimetypeClear() void {
+    fio.http_mimetype_clear();
 }

--- a/src/request.zig
+++ b/src/request.zig
@@ -470,7 +470,7 @@ pub const HttpHeaderCommon = enum(usize) {
     /// Represents the HTTP Header "Host".
     host,
     /// Represents the HTTP Header "Last-Modified".
-    last_modifed,
+    last_modified,
     /// Represents the HTTP Header "Origin".
     origin,
     /// Represents the HTTP Header "Set-Cookie".

--- a/tools/docserver.zig
+++ b/tools/docserver.zig
@@ -26,14 +26,7 @@ pub fn main() !void {
         }
     }
 
-    const ext = "wasm";
-    var buf: [0xF]u8 = undefined;
-    @memcpy(buf[0..ext.len], ext);
-
-    const mimetype = "application/wasm";
-    const fio_mimetype = zap.fio.fiobj_str_new(mimetype[0..], mimetype.len);
-
-    zap.fio.http_mimetype_register(buf[0..ext.len], ext.len, fio_mimetype);
+    zap.mimetypeRegister("wasm", "application/wasm");
 
     var listener = zap.HttpListener.init(.{
         .port = port,

--- a/tools/docserver.zig
+++ b/tools/docserver.zig
@@ -26,6 +26,15 @@ pub fn main() !void {
         }
     }
 
+    const ext = "wasm";
+    var buf: [0xF]u8 = undefined;
+    @memcpy(buf[0..ext.len], ext);
+
+    const mimetype = "application/wasm";
+    const fio_mimetype = zap.fio.fiobj_str_new(mimetype[0..], mimetype.len);
+
+    zap.fio.http_mimetype_register(buf[0..ext.len], ext.len, fio_mimetype);
+
     var listener = zap.HttpListener.init(.{
         .port = port,
         .on_request = on_request,


### PR DESCRIPTION
Makes `run-docserver` use the generated files as the docs root automatically. Adds 2 new functions, `zap.mimetypeRegister` and `zap.mimetypeClear`. This was needed to serve the webassembly modules from the docs in a way browsers will accept.