### PR TITLE
Fix build.zig to allow cross compilation on windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,9 +13,10 @@ pub fn build(b: *std.Build) !void {
 
     const use_openssl = b.option(bool, "openssl", "Use system-installed openssl for TLS support in zap") orelse blk: {
         // Alternatively, use an os env var to determine whether to build openssl support
-        if (std.posix.getenv("ZAP_USE_OPENSSL")) |val| {
+        if (std.process.getEnvVarOwned(b.allocator, "ZAP_USE_OPENSSL")) |val| {
+            defer b.allocator.free(val);
             if (std.mem.eql(u8, val, "true")) break :blk true;
-        }
+        } else |_| {}
         break :blk false;
     };
 


### PR DESCRIPTION
By replacing the linux only `std.posix.getenv` with the cross platform `std.process.getEnvVarOwned` in `build.zig` it is now possible to cross compile zap on a windows host.