### PR TITLE
include BuildResult in public Mustache API

### DIFF
--- a/src/mustache.zig
+++ b/src/mustache.zig
@@ -113,7 +113,7 @@ pub fn deinit(self: *Self) void {
 // pub extern fn fiobj_mustache_build2(dest: FIOBJ, mustache: ?*mustache_s, data: FIOBJ) FIOBJ;
 
 /// The result from calling `build`.
-const MustacheBuildResult = struct {
+pub const BuildResult = struct {
     fiobj_result: fio.FIOBJ = 0,
 
     /// Holds the context converted into a fiobj.
@@ -121,13 +121,13 @@ const MustacheBuildResult = struct {
     fiobj_context: fio.FIOBJ = 0,
 
     /// Free the data backing a `MustacheBuildResult` instance.
-    pub fn deinit(m: *const MustacheBuildResult) void {
+    pub fn deinit(m: *const BuildResult) void {
         fio.fiobj_free_wrapped(m.fiobj_result);
         fio.fiobj_free_wrapped(m.fiobj_context);
     }
 
     /// Retrieve a string representation of the built template.
-    pub fn str(m: *const MustacheBuildResult) ?[]const u8 {
+    pub fn str(m: *const BuildResult) ?[]const u8 {
         return util.fio2str(m.fiobj_result);
     }
 };
@@ -137,13 +137,13 @@ const MustacheBuildResult = struct {
 // TODO: The build may be slow because it needs to convert zig types to facil.io
 // types. However, this needs to be investigated into.
 // See `fiobjectify` for more information.
-pub fn build(self: *Self, data: anytype) MustacheBuildResult {
+pub fn build(self: *Self, data: anytype) BuildResult {
     const T = @TypeOf(data);
     if (@typeInfo(T) != .Struct) {
         @compileError("No struct: '" ++ @typeName(T) ++ "'");
     }
 
-    var result: MustacheBuildResult = .{};
+    var result: BuildResult = .{};
 
     result.fiobj_context = fiobjectify(data);
     result.fiobj_result = fiobj_mustache_build(self.handle, result.fiobj_context);

--- a/src/mustache.zig
+++ b/src/mustache.zig
@@ -15,7 +15,7 @@ extern fn fiobj_mustache_build2(dest: fio.FIOBJ, mustache: ?*mustache_s, data: f
 extern fn fiobj_mustache_free(mustache: ?*mustache_s) void;
 
 /// Load arguments used when creating a new Mustache instance.
-pub const MustacheLoadArgs = struct {
+pub const LoadArgs = struct {
     /// Filename. This enables partial templates on filesystem.
     filename: ?[]const u8 = null,
 
@@ -51,7 +51,7 @@ pub const Error = error{
 
 /// Create a new `Mustache` instance; `deinit()` should be called to free
 /// the object after usage.
-pub fn init(load_args: MustacheLoadArgs) Error!Self {
+pub fn init(load_args: LoadArgs) Error!Self {
     var err: mustache_error_en = undefined;
 
     const args: MustacheLoadArgsFio = .{


### PR DESCRIPTION
This small PR includes the Mustache build results in the public API to allow developers to better annotate types and pass the build result around if needed.
 
The discussion for this originated on Discord, so I'll include the important bits below for future readers:

> **me:** Is there a design decision behind why the `MustacheBuildResult` type isn't marked public?

> **renerocksai:** At the time, I probably thought it wouldn't be necessary to make it public, as it is returned by a pub fn anyway, which makes it kind-of-public. This choice makes it impossible (I think) to declare variables of this type in user code and encourages just assigning the result of the build function. 
>
> Do you have a need for `var x : zap.Mustache.MustacheBuildResult = .{}`  and assigning later or similar? Ah, maybe passing it around or storing it in your own struct: I would rather use its `.str()` result to hold on to.
>
> Feel free to submit a PR to make it pub. I might do so myself; but then I'd strip the Mustache off the type names (type shaving 🤣) of the load args and the build result.

> **me:** I've switched to passing around strings at this point (maybe that's better anyway...?), but I found it strange that I couldn't add annotations for a return type of a public function. Not saying I need it changed; I just found it slightly jarring from an API perspective.