### PR TITLE
perf-measures: re-introduce httpz

### DIFF
--- a/wrk/httpz/build.zig
+++ b/wrk/httpz/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "httpz",
+        .root_source_file = b.path("main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const httpz = b.dependency("httpz", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // the executable from your call to b.addExecutable(...)
+    exe.root_module.addImport("httpz", httpz.module("httpz"));
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/wrk/httpz/build.zig.zon
+++ b/wrk/httpz/build.zig.zon
@@ -1,0 +1,39 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "httpz",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        .httpz = .{
+            .url = "git+https://github.com/karlseguin/http.zig?ref=master#ffdce2eeb8499c0b5001f5c5bf141cc33c22b215",
+            .hash = "12209018285fde7ae6216acafe44fc199036239e1f24bda2b513bbcc1b6bc9a70752",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/wrk/httpz/main.zig
+++ b/wrk/httpz/main.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{
+        .thread_safe = true,
+    }){};
+    const allocator = gpa.allocator();
+
+    var server = try httpz.Server(void).init(allocator, .{ .port = 3000 }, {});
+
+    defer server.deinit();
+    var router = server.router(.{});
+
+    router.get("/", index, .{});
+    try server.listen();
+}
+
+fn index(_: *httpz.Request, res: *httpz.Response) !void {
+    res.body = "HI FROM ZIG-HTTPZ";
+}

--- a/wrk/measure.sh
+++ b/wrk/measure.sh
@@ -9,6 +9,11 @@ SUBJECT=$1
 TSK_SRV="taskset -c 0,1,2,3"
 TSK_LOAD="taskset -c 4,5,6,7"
 
+if [ $(echo $(uname)) = "Darwin" ] ; then
+    TSK_SRV=""
+    TSK_LOAD=""
+fi
+
 if [ "$SUBJECT" = "" ] ; then
     echo "usage: $0 subject    # subject: zig or go"
     exit 1
@@ -17,6 +22,14 @@ fi
 if [ "$SUBJECT" = "zig-zap" ] ; then
     zig build -Doptimize=ReleaseFast wrk > /dev/null
     $TSK_SRV ./zig-out/bin/wrk &
+    PID=$!
+    URL=http://127.0.0.1:3000
+fi
+
+if [ "$SUBJECT" = "httpz" ] ; then
+    cd wrk/httpz
+    zig build -Doptimize=ReleaseFast > /dev/null
+    $TSK_SRV ./zig-out/bin/httpz &
     PID=$!
     URL=http://127.0.0.1:3000
 fi


### PR DESCRIPTION
In the 0.12.0 branch, [httpz](https://github.com/karlseguin/http.zig) was added to the perf measurements.

Apparently, somehow this got lost, which is a pity. httpz is super-promising.

Given the perf benchmarks in [this
PR comment](https://github.com/antonputra/tutorials/pull/280#issuecomment-2362637299), I would have expected httpz to be on par with or better than zap in our `measure.sh` tests.

However, on my M3 max mac box, I get the following:

**ZAP**:

```
➜  zap git:(reintroduce_httpz_perf) ✗ ./wrk/measure.sh zig-zap
INFO: Listening on port 3000
Listening on 0.0.0.0:3000
INFO: Server is running 4 workers X 4 threads with facil.io 0.7.4 (kqueue)
* Detected capacity: 131056 open file limit
* Root pid: 73099
* Press ^C to stop

INFO: 73110 is running.
INFO: 73111 is running.
INFO: 73112 is running.
INFO: 73113 is running.
========================================================================
                          zig-zap
========================================================================
Running 10s test @ http://127.0.0.1:3000
  4 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.31ms  533.41us  18.77ms   90.57%
    Req/Sec    76.67k     9.04k   86.46k    84.25%
  Latency Distribution
     50%    1.15ms
     75%    1.17ms
     90%    1.75ms
     99%    2.94ms
  3052064 requests in 10.02s, 462.80MB read
  Socket errors: connect 0, read 135, write 0, timeout 0
Requests/sec: 304601.19
Transfer/sec:     46.19MB
```

**httpz**:

```
➜  zap git:(reintroduce_httpz_perf) ✗ ./wrk/measure.sh httpz
========================================================================
                          httpz
========================================================================
Running 10s test @ http://127.0.0.1:3000
  4 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.26ms  528.72us  18.84ms   84.61%
    Req/Sec    44.46k     7.35k   85.50k    88.00%
  Latency Distribution
     50%    2.35ms
     75%    2.39ms
     90%    2.43ms
     99%    3.26ms
  1768925 requests in 10.01s, 91.10MB read
  Socket errors: connect 0, read 230, write 0, timeout 0
Requests/sec: 176712.50
Transfer/sec:      9.10MB
```

Which looks way off. I must admit, I might have done a bad httpz implementation.

Seeking help from @karlseguin. My motivation: route people away from zap to alternatives like httpz or even zzz, as those are pure zig, and seem to be of really good performance. I want a world in which we don't have to resort to C frameworks to do good, zig-worthy servers :smile: to come true.