### PR TITLE
Fix deprecated warning in facil.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ scratch
 .vs/
 **/*.perflog
 wrk/*.png
+.zig-cache/

--- a/facil.io/lib/facil/http/websockets.c
+++ b/facil.io/lib/facil/http/websockets.c
@@ -96,7 +96,7 @@ void free_ws_buffer(ws_s *owner, struct buffer_s buff) {
 Create/Destroy the websocket object (prototypes)
 */
 
-static ws_s *new_websocket();
+static ws_s *new_websocket(intptr_t uuid);
 static void destroy_ws(ws_s *ws);
 
 /*******************************************************************************


### PR DESCRIPTION
This PR fixes a compiler warning in the `websockets.c` file regarding a _deprecated non-prototype function declaration_. The warning occurs because the `new_websocket` function is initially declared without a prototype but is later defined with a parameter.

The warning looks like this:
```logs
facil.io/lib/facil/http/websockets.c:99:14: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
   99 | static ws_s *new_websocket();
      |              ^
facil.io/lib/facil/http/websockets.c:305:14: note: conflicting prototype is here
  305 | static ws_s *new_websocket(intptr_t uuid) {
      |              ^
```

I encountered this issue while integrating Zap as a zig library in a zig / bazel project (see : https://github.com/vctrmn/zig-text-embeddings-inference) 

If you are interested into this topic, I can also upload the BUILD.bazel to showcase how to integrate it.
