### PR TITLE
fix: add missing head handler for EndpointType

### DIFF
--- a/examples/app/auth.zig
+++ b/examples/app/auth.zig
@@ -65,6 +65,7 @@ const MyEndpoint = struct {
     pub fn delete(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn patch(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn options(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
+    pub fn head(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 pub fn main() !void {

--- a/examples/app/basic.zig
+++ b/examples/app/basic.zig
@@ -66,6 +66,7 @@ const SimpleEndpoint = struct {
     pub fn delete(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn patch(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn options(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
+    pub fn head(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 const StopEndpoint = struct {

--- a/examples/app/errors.zig
+++ b/examples/app/errors.zig
@@ -53,6 +53,7 @@ const ErrorEndpoint = struct {
     pub fn delete(_: *ErrorEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn patch(_: *ErrorEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn options(_: *ErrorEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
+    pub fn head(_: *ErrorEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 const StopEndpoint = struct {

--- a/examples/endpoint/error.zig
+++ b/examples/endpoint/error.zig
@@ -20,3 +20,4 @@ pub fn put(_: *ErrorEndpoint, _: zap.Request) !void {}
 pub fn delete(_: *ErrorEndpoint, _: zap.Request) !void {}
 pub fn patch(_: *ErrorEndpoint, _: zap.Request) !void {}
 pub fn options(_: *ErrorEndpoint, _: zap.Request) !void {}
+pub fn head(_: *ErrorEndpoint, _: zap.Request) !void {}

--- a/examples/endpoint/stopendpoint.zig
+++ b/examples/endpoint/stopendpoint.zig
@@ -23,3 +23,4 @@ pub fn put(_: *StopEndpoint, _: zap.Request) !void {}
 pub fn delete(_: *StopEndpoint, _: zap.Request) !void {}
 pub fn patch(_: *StopEndpoint, _: zap.Request) !void {}
 pub fn options(_: *StopEndpoint, _: zap.Request) !void {}
+pub fn head(_: *StopEndpoint, _: zap.Request) !void {}

--- a/examples/endpoint/userweb.zig
+++ b/examples/endpoint/userweb.zig
@@ -127,7 +127,12 @@ pub fn delete(self: *UserWeb, r: zap.Request) !void {
 
 pub fn options(_: *UserWeb, r: zap.Request) !void {
     try r.setHeader("Access-Control-Allow-Origin", "*");
-    try r.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+    try r.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD");
+    r.setStatus(zap.http.StatusCode.no_content);
+    r.markAsFinished(true);
+}
+
+pub fn head(_: *UserWeb, r: zap.Request) !void {
     r.setStatus(zap.http.StatusCode.no_content);
     r.markAsFinished(true);
 }

--- a/examples/endpoint_auth/endpoint_auth.zig
+++ b/examples/endpoint_auth/endpoint_auth.zig
@@ -38,6 +38,7 @@ const Endpoint = struct {
     pub fn delete(_: *Endpoint, _: zap.Request) !void {}
     pub fn patch(_: *Endpoint, _: zap.Request) !void {}
     pub fn options(_: *Endpoint, _: zap.Request) !void {}
+    pub fn head(_: *Endpoint, _: zap.Request) !void {}
 };
 
 pub fn main() !void {

--- a/examples/middleware_with_endpoint/middleware_with_endpoint.zig
+++ b/examples/middleware_with_endpoint/middleware_with_endpoint.zig
@@ -157,6 +157,7 @@ const HtmlEndpoint = struct {
     pub fn delete(_: *HtmlEndpoint, _: zap.Request) !void {}
     pub fn patch(_: *HtmlEndpoint, _: zap.Request) !void {}
     pub fn options(_: *HtmlEndpoint, _: zap.Request) !void {}
+    pub fn head(_: *HtmlEndpoint, _: zap.Request) !void {}
 
     pub fn get(_: *HtmlEndpoint, r: zap.Request) !void {
         var buf: [1024]u8 = undefined;

--- a/src/App.zig
+++ b/src/App.zig
@@ -117,6 +117,7 @@ pub fn Create(
                             .DELETE => self.endpoint.*.delete(arena, app_context, r),
                             .PATCH => self.endpoint.*.patch(arena, app_context, r),
                             .OPTIONS => self.endpoint.*.options(arena, app_context, r),
+                            .HEAD => self.endpoint.*.head(arena, app_context, r),
                             else => error.UnsupportedHtmlRequestMethod,
                         };
                         if (ret) {
@@ -173,6 +174,7 @@ pub fn Create(
                     "delete",
                     "patch",
                     "options",
+                    "head",
                 };
                 const params_to_check = [_]type{
                     *T,
@@ -302,6 +304,15 @@ pub fn Create(
                         try switch (self.authenticator.authenticateRequest(&request)) {
                             .AuthFailed => return self.ep.*.unauthorized(arena, context, request),
                             .AuthOK => self.ep.*.put(arena, context, request),
+                            .Handled => {},
+                        };
+                    }
+
+                    /// Authenticates HEAD requests using the Authenticator.
+                    pub fn head(self: *AuthenticatingEndpoint, arena: Allocator, context: *Context, request: zap.Request) anyerror!void {
+                        try switch (self.authenticator.authenticateRequest(&request)) {
+                            .AuthFailed => return self.ep.*.unauthorized(arena, context, request),
+                            .AuthOK => self.ep.*.head(arena, context, request),
                             .Handled => {},
                         };
                     }

--- a/src/endpoint.zig
+++ b/src/endpoint.zig
@@ -19,6 +19,7 @@
 //! pub fn delete(_: *Self, _: zap.Request) !void {}
 //! pub fn patch(_: *Self, _: zap.Request) !void {}
 //! pub fn options(_: *Self, _: zap.Request) !void {}
+//! pub fn head(_: *Self, _: zap.Request) !void {}
 //!
 //! // optional, if auth stuff is used:
 //! pub fn unauthorized(_: *Self, _: zap.Request) !void {}
@@ -49,6 +50,7 @@
 //!     pub fn delete(_: *StopEndpoint, _: zap.Request) !void {}
 //!     pub fn patch(_: *StopEndpoint, _: zap.Request) !void {}
 //!     pub fn options(_: *StopEndpoint, _: zap.Request) !void {}
+//!     pub fn head(_: *StopEndpoint, _: zap.Request) !void {}
 //! };
 //! ```
 
@@ -97,6 +99,7 @@ pub fn checkEndpointType(T: type) void {
         "delete",
         "patch",
         "options",
+        "head",
     };
 
     const params_to_check = [_]type{
@@ -192,6 +195,7 @@ pub const Binder = struct {
                     .DELETE => self.endpoint.*.delete(r),
                     .PATCH => self.endpoint.*.patch(r),
                     .OPTIONS => self.endpoint.*.options(r),
+                    .HEAD => self.endpoint.*.head(r),
                     else => error.UnsupportedHtmlRequestMethod,
                 };
                 if (ret) {
@@ -292,6 +296,15 @@ pub fn Authenticating(EndpointType: type, Authenticator: type) type {
             try switch (self.authenticator.authenticateRequest(&r)) {
                 .AuthFailed => return self.ep.*.unauthorized(r),
                 .AuthOK => self.ep.*.put(r),
+                .Handled => {},
+            };
+        }
+        
+        /// Authenticates HEAD requests using the Authenticator.
+        pub fn head(self: *AuthenticatingEndpoint, r: zap.Request) anyerror!void {
+            try switch (self.authenticator.authenticateRequest(&r)) {
+                .AuthFailed => return self.ep.*.unauthorized(r),
+                .AuthOK => self.ep.*.head(r),
                 .Handled => {},
             };
         }

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -109,6 +109,7 @@ pub fn EndpointHandler(comptime HandlerType: anytype, comptime EndpointType: any
                     .DELETE => try self.endpoint.*.delete(r),
                     .PATCH => try self.endpoint.*.patch(r),
                     .OPTIONS => try self.endpoint.*.options(r),
+                    .HEAD => try self.endpoint.*.head(r),
                     else => {},
                 }
             }

--- a/src/tests/test_auth.zig
+++ b/src/tests/test_auth.zig
@@ -170,6 +170,7 @@ pub const Endpoint = struct {
     pub fn delete(_: *Endpoint, _: zap.Request) !void {}
     pub fn patch(_: *Endpoint, _: zap.Request) !void {}
     pub fn options(_: *Endpoint, _: zap.Request) !void {}
+    pub fn head(_: *Endpoint, _: zap.Request) !void {}
 };
 //
 // end of http client code


### PR DESCRIPTION
This pull request introduces support for the HTTP `HEAD` method across various endpoints and structures in the codebase. It ensures that `HEAD` requests are properly handled in both core functionality and examples, while also updating related authentication and middleware logic.

### Support for `HEAD` method in endpoints:

* Added `head` method to multiple endpoint structs, including `MyEndpoint`, `SimpleEndpoint`, `ErrorEndpoint`, `StopEndpoint`, `HtmlEndpoint`, and `UserWeb`, enabling them to handle `HEAD` requests. (`[[1]](diffhunk://#diff-146a459eb4ae8d10d2699ccb000c4f6a750d9a8bd4c25290d0b212db3f74dec3R68)`, `[[2]](diffhunk://#diff-3bdafe3135ec8926afcba258bffc5ebacb513f1a41b508e91f6bbaf0b40aad10R69)`, `[[3]](diffhunk://#diff-76e6ff01f25c8c789cc21480ddc2b2e0418780e50a9ae5f14041199c079c7faeR56)`, `[[4]](diffhunk://#diff-a5c3f42c7324c64cc8830efcb8822a1ada8540d9d66135f67b2cf97fb58c103dR26)`, `[[5]](diffhunk://#diff-ba39abdb36f2a4f6fc4ec388f86acb13dbc342d7f9aeca599550e4dd60271242R160)`, `[[6]](diffhunk://#diff-cd028a11497e4e351d65564f1915f763908f20bacf6587b88a83064585cc508cL130-R135)`)
* Updated `UserWeb`'s `options` method to include `HEAD` in the `Access-Control-Allow-Methods` header. (`[examples/endpoint/userweb.zigL130-R135](diffhunk://#diff-cd028a11497e4e351d65564f1915f763908f20bacf6587b88a83064585cc508cL130-R135)`)

### Core framework updates for `HEAD` method:

* Modified `src/App.zig` to route `HEAD` requests to the appropriate `head` method in the endpoint. (`[src/App.zigR120](diffhunk://#diff-aa9d26de9c6c82b2d1d0829bdd7b5c6bf4b8ce3968b9079121806eea654e1f25R120)`)
* Added `head` to the list of supported HTTP methods in `src/App.zig`. (`[src/App.zigR177](diffhunk://#diff-aa9d26de9c6c82b2d1d0829bdd7b5c6bf4b8ce3968b9079121806eea654e1f25R177)`)
* Introduced authentication logic for `HEAD` requests in `src/App.zig` and `src/endpoint.zig`, ensuring proper handling of authenticated `HEAD` requests. (`[[1]](diffhunk://#diff-aa9d26de9c6c82b2d1d0829bdd7b5c6bf4b8ce3968b9079121806eea654e1f25R310-R318)`, `[[2]](diffhunk://#diff-b6751b13bfcd4e31d24370fa695d8d43f27d86397e31e166572047b340cec172R302-R310)`)

### Documentation and validation updates:

* Updated comments and validation logic in `src/endpoint.zig` to include the `head` method. (`[[1]](diffhunk://#diff-b6751b13bfcd4e31d24370fa695d8d43f27d86397e31e166572047b340cec172R22)`, `[[2]](diffhunk://#diff-b6751b13bfcd4e31d24370fa695d8d43f27d86397e31e166572047b340cec172R53)`, `[[3]](diffhunk://#diff-b6751b13bfcd4e31d24370fa695d8d43f27d86397e31e166572047b340cec172R102)`)

### Middleware and testing:

* Enhanced middleware in `src/middleware.zig` to process `HEAD` requests. (`[src/middleware.zigR112](diffhunk://#diff-96eb9e5cbd3c1ba3aac8e9cf89868e6309f0ef17e40bcf0dd85ff3b21cc9482cR112)`)
* Added `head` method to the test `Endpoint` struct in `src/tests/test_auth.zig` to ensure test coverage for `HEAD` requests. (`[src/tests/test_auth.zigR173](diffhunk://#diff-a2d4c702afe4c486e4acb56e8d068fb5e989c8c53fb0f610fe361655d325d7b0R173)`)