### PR TITLE
Accept file with no specified Content-Type

### DIFF
--- a/src/request.zig
+++ b/src/request.zig
@@ -125,11 +125,18 @@ fn parseBinfilesFrom(a: Allocator, o: fio.FIOBJ) !HttpParam {
         fio.fiobj_free_wrapped(key_name);
         fio.fiobj_free_wrapped(key_data);
         fio.fiobj_free_wrapped(key_type);
-    } // files: they should have "data", "type", and "filename" keys
-    if (fio.fiobj_hash_haskey(o, key_data) == 1 and fio.fiobj_hash_haskey(o, key_type) == 1 and fio.fiobj_hash_haskey(o, key_name) == 1) {
+    } // files: they should have "data" and "filename" keys
+    if (fio.fiobj_hash_haskey(o, key_data) == 1 and fio.fiobj_hash_haskey(o, key_name) == 1) {
         const filename = fio.fiobj_obj2cstr(fio.fiobj_hash_get(o, key_name));
-        const mimetype = fio.fiobj_obj2cstr(fio.fiobj_hash_get(o, key_type));
         const data = fio.fiobj_hash_get(o, key_data);
+
+        var mimetype: []const u8 = undefined;
+        if (fio.fiobj_hash_haskey(o, key_type) == 1) {
+            const mt = fio.fiobj_obj2cstr(fio.fiobj_hash_get(o, key_type));
+            mimetype = mt.data[0..mt.len];
+        } else {
+            mimetype = &"application/octet-stream".*;
+        }
 
         var data_slice: ?[]const u8 = null;
 
@@ -221,7 +228,7 @@ fn parseBinfilesFrom(a: Allocator, o: fio.FIOBJ) !HttpParam {
 
         return .{ .Hash_Binfile = .{
             .filename = filename.data[0..filename.len],
-            .mimetype = mimetype.data[0..mimetype.len],
+            .mimetype = mimetype,
             .data = data_slice,
         } };
     } else {


### PR DESCRIPTION
When uploading a file via cURL, if it doesn't know what type the file is then it just does not include the `Content-Type` field in the parameter.  
eg.
```
echo "This is my file content" |  curl -F 'file=@-' http://localhost:3000/
```
In this case, zap will receive a Hash_Binfile parameter but its content will be empty.  
The behavior of cURL seems to be non standard, as the [RFC 1867: Form-based File Upload in HTML](https://www.rfc-editor.org/rfc/rfc1867#section-3.3) states:  

>    The definition of multipart/form-data is included in [section 7](https://www.rfc-editor.org/rfc/rfc1867#section-7).  A
   boundary is selected that does not occur in any of the data. (This
   selection is sometimes done probabilisticly.) Each field of the form
   is sent, in the order in which it occurs in the form, as a part of
   the multipart stream.  Each part identifies the INPUT name within the
   original HTML form. **Each part should be labelled with an appropriate
   content-type if the media type is known** (e.g., inferred from the file
   extension or operating system typing information) **or as
   application/octet-stream.**

For that reason, I am proposing this patch where in case the client (cURL) did not specify the `Content-Type` of an uploaded file, then zap will default to `"application/octet-stream"`.  
This will allow files uploaded without specified types to still be received by applications using zap.


I tried adding unit test for that by adding a `src/tests/test_recvfile.zig` and a `src/tests/test_recvfile_notype.zig` tests, but I eventually gave up after spending most of my day failing to send an HTTP POST request with form field containing a file, using `std.http.Client.fetch` function.  
I'd be very happy to create an automatic test, but I would need help doing so. Maybe it'd be cool if we could use cURL in the test? I didn't really want to introduce new dependencies as a first time contributor though, tell me if that'd be a good idea and I may look into it.



# Full program to reproduce

```zig
const std = @import("std");
const zap = @import("zap");
const Allocator = std.mem.Allocator;

fn on_request(r: zap.Request) !void {
    r.parseBody() catch @panic("Failed to parse request body");

    if (r.getParamCount() != 1) @panic("Expected exactly one parameter");

    var alloc = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer alloc.deinit();
    const params = r.parametersToOwnedList(alloc.allocator()) catch {
        r.setStatus(.internal_server_error);
        r.sendBody("Internal server error") catch {};
        return;
    };

    const value = params.items[0].value orelse @panic("Parameter has no value");

    const file = switch (value) {
        .Hash_Binfile => |f| f,
        else => @panic("Parameter is not a file"),
    };

    const content = file.data orelse @panic("File has no data");

    std.debug.print("File content:\n----\n{s}\n----\n", .{content});
}

pub fn main() !void {
    var listener = zap.HttpListener.init(.{
        .port = 3000,
        .on_request = on_request,
        .log = true,
    });
    try listener.listen();

    std.debug.print("Listening on 0.0.0.0:3000\n", .{});

    zap.start(.{
        .threads = 2,
        .workers = 2,
    });
}
```
Build with zap 0.10.1:
```
    .dependencies = .{
        .zap = .{
            .url = "git+https://github.com/zigzap/zap?ref=v0.10.1#8d187310c7ee4f86faa7ef0ecdac0bf747216dea",
            .hash = "zap-0.9.1-GoeB84M8JACjZKDNq2LA5hB24Z-ZrZ_HUKRXd8qxL2JW",
        },
    },
```

----

First request with cURL (works as expected):
```
$  echo "This is my file" | curl -F 'file=@-;type=text/plain' http://localhost:3000/
```
Wireshark capture of the relevant HTTP packet:
![image](https://github.com/user-attachments/assets/44206c49-9f1a-429e-a1ce-96d89e0c1131)
*note the `Content-Type: text/plain`*

server logs:
```
File content:
----
This is my file
----
127.0.0.1 - - [Sun, 04 May 2025 06:46:24 GMT] "POST / HTTP/1.1" 200 -- 351us
```

----

Second request with cURL (does not work as expected):
```
$ echo "This is my file" | curl -F 'file=@-' http://localhost:3000/
```
Wireshark capture of the relevant HTTP packet:
![image](https://github.com/user-attachments/assets/5f0231f6-9b9f-46b7-9514-79ddc07d4e0a)
*note the absence of `Content-Type:text/plain`*

server logs:
```
thread 71754 panic: File has no data
/home/yanis/project/src/main.zig:25:38: 0x11056e4 in on_request (project)
    const content = file.data orelse @panic("File has no data");
[...]
```