### PR TITLE
Log: remove additional newlines due to Zig's default log fn

### DIFF
--- a/examples/bindataformpost/bindataformpost.zig
+++ b/examples/bindataformpost/bindataformpost.zig
@@ -25,7 +25,7 @@ const Handler = struct {
         };
 
         if (r.body) |body| {
-            std.log.info("Body length is {any}\n", .{body.len});
+            std.log.info("Body length is {any}", .{body.len});
         }
 
         // parse potential query params (for ?terminate=true)
@@ -43,7 +43,7 @@ const Handler = struct {
         for (params.items) |kv| {
             if (kv.value) |v| {
                 std.debug.print("\n", .{});
-                std.log.info("Param `{s}` in owned list is {any}\n", .{ kv.key, v });
+                std.log.info("Param `{s}` in owned list is {any}", .{ kv.key, v });
                 switch (v) {
                     // single-file upload
                     zap.Request.HttpParam.Hash_Binfile => |*file| {
@@ -51,9 +51,9 @@ const Handler = struct {
                         const mimetype = file.mimetype orelse "(no mimetype)";
                         const data = file.data orelse "";
 
-                        std.log.debug("    filename: `{s}`\n", .{filename});
-                        std.log.debug("    mimetype: {s}\n", .{mimetype});
-                        std.log.debug("    contents: {any}\n", .{data});
+                        std.log.debug("    filename: `{s}`", .{filename});
+                        std.log.debug("    mimetype: {s}", .{mimetype});
+                        std.log.debug("    contents: {any}", .{data});
                     },
                     // multi-file upload
                     zap.Request.HttpParam.Array_Binfile => |*files| {
@@ -62,9 +62,9 @@ const Handler = struct {
                             const mimetype = file.mimetype orelse "(no mimetype)";
                             const data = file.data orelse "";
 
-                            std.log.debug("    filename: `{s}`\n", .{filename});
-                            std.log.debug("    mimetype: {s}\n", .{mimetype});
-                            std.log.debug("    contents: {any}\n", .{data});
+                            std.log.debug("    filename: `{s}`", .{filename});
+                            std.log.debug("    mimetype: {s}", .{mimetype});
+                            std.log.debug("    contents: {any}", .{data});
                         }
                         files.*.deinit();
                     },
@@ -79,7 +79,7 @@ const Handler = struct {
 
         // check if we received a terminate=true parameter
         if (r.getParamSlice("terminate")) |str| {
-            std.log.info("?terminate={s}\n", .{str});
+            std.log.info("?terminate={s}", .{str});
             if (std.mem.eql(u8, str, "true")) {
                 zap.stop();
             }
@@ -110,9 +110,9 @@ pub fn main() !void {
     );
 
     try listener.listen();
-    std.log.info("\n\nURL is http://localhost:3000\n", .{});
-    std.log.info("\ncurl -v --request POST -F img=@test012345.bin http://127.0.0.1:3000\n", .{});
-    std.log.info("\n\nTerminate with CTRL+C or by sending query param terminate=true\n", .{});
+    std.log.info("\n\nURL is http://localhost:3000", .{});
+    std.log.info("\ncurl -v --request POST -F img=@test012345.bin http://127.0.0.1:3000", .{});
+    std.log.info("\n\nTerminate with CTRL+C or by sending query param terminate=true", .{});
 
     zap.start(.{
         .threads = 1,

--- a/examples/cookies/cookies.zig
+++ b/examples/cookies/cookies.zig
@@ -87,8 +87,8 @@ pub fn main() !void {
                     std.log.info("Cookie ZIG_ZAP not found!", .{});
                 }
             } else |err| {
-                std.log.err("ERROR!\n", .{});
-                std.log.err("cannot check for `ZIG_ZAP` cookie: {any}\n", .{err});
+                std.log.err("ERROR!", .{});
+                std.log.err("cannot check for `ZIG_ZAP` cookie: {any}", .{err});
             }
 
             r.setCookie(.{
@@ -101,8 +101,8 @@ pub fn main() !void {
                 //
                 // check out other params: domain, path, secure, http_only
             }) catch |err| {
-                std.log.err("ERROR!\n", .{});
-                std.log.err("cannot set cookie: {any}\n", .{err});
+                std.log.err("ERROR!", .{});
+                std.log.err("cannot set cookie: {any}", .{err});
             };
 
             r.sendBody("Hello") catch unreachable;

--- a/examples/endpoint/main.zig
+++ b/examples/endpoint/main.zig
@@ -86,5 +86,5 @@ pub fn main() !void {
 
     // show potential memory leaks when ZAP is shut down
     const has_leaked = gpa.detectLeaks();
-    std.log.debug("Has leaked: {}\n", .{has_leaked});
+    std.log.debug("Has leaked: {}", .{has_leaked});
 }

--- a/examples/http_params/http_params.zig
+++ b/examples/http_params/http_params.zig
@@ -111,7 +111,7 @@ pub fn main() !void {
                     std.log.info("Param one not found!", .{});
                 }
             } else |err| {
-                std.log.err("cannot check for `one` param: {any}\n", .{err});
+                std.log.err("cannot check for `one` param: {any}", .{err});
             }
 
             // check if we received a terminate=true parameter
@@ -137,7 +137,7 @@ pub fn main() !void {
     );
 
     try listener.listen();
-    std.log.info("\n\nTerminate with CTRL+C or by sending query param terminate=true\n", .{});
+    std.log.info("\n\nTerminate with CTRL+C or by sending query param terminate=true", .{});
 
     const thread = try makeRequestThread(allocator, "http://127.0.0.1:3000/?one=1&two=2&string=hello+world&float=6.28&bool=true");
     defer thread.join();

--- a/src/http_auth.zig
+++ b/src/http_auth.zig
@@ -440,9 +440,9 @@ pub fn UserPassSession(comptime Lookup: type, comptime lockedPwLookups: bool) ty
                 .value = "invalid",
                 .max_age_s = -1,
             })) {
-                zap.debug("logout ok\n", .{});
+                zap.debug("logout ok", .{});
             } else |err| {
-                zap.debug("logout cookie setting failed: {any}\n", .{err});
+                zap.debug("logout cookie setting failed: {any}", .{err});
             }
 
             r.parseCookies(false);

--- a/src/request.zig
+++ b/src/request.zig
@@ -137,24 +137,24 @@ fn parseBinfilesFrom(a: Allocator, o: fio.FIOBJ) !HttpParam {
             fio.FIOBJ_T_DATA => {
                 if (fio.is_invalid(data) == 1) {
                     data_slice = "(zap: invalid data)";
-                    zap.log.warn("HTTP param binary file is not a data object\n", .{});
+                    zap.log.warn("HTTP param binary file is not a data object", .{});
                 } else {
                     // the data
                     const data_len = fio.fiobj_data_len(data);
                     var data_buf = fio.fiobj_data_read(data, data_len);
 
                     if (data_len < 0) {
-                        zap.log.warn("HTTP param binary file size negative: {d}\n", .{data_len});
-                        zap.log.warn("FIOBJ_TYPE of data is: {d}\n", .{fio.fiobj_type(data)});
+                        zap.log.warn("HTTP param binary file size negative: {d}", .{data_len});
+                        zap.log.warn("FIOBJ_TYPE of data is: {d}", .{fio.fiobj_type(data)});
                     } else {
                         if (data_buf.len != data_len) {
-                            zap.log.warn("HTTP param binary file size mismatch: should {d}, is: {d}\n", .{ data_len, data_buf.len });
+                            zap.log.warn("HTTP param binary file size mismatch: should {d}, is: {d}", .{ data_len, data_buf.len });
                         }
 
                         if (data_buf.len > 0) {
                             data_slice = data_buf.data[0..data_buf.len];
                         } else {
-                            zap.log.warn("HTTP param binary file buffer size negative: {d}\n", .{data_buf.len});
+                            zap.log.warn("HTTP param binary file buffer size negative: {d}", .{data_buf.len});
                             data_slice = "(zap: invalid data: negative BUFFER size)";
                         }
                     }
@@ -379,7 +379,7 @@ pub fn setContentType(self: *const Request, c: ContentType) HttpError!void {
         .JSON => "application/json",
         else => "text/html",
     };
-    zap.log.debug("setting content-type to {s}\n", .{s});
+    zap.log.debug("setting content-type to {s}", .{s});
     return self.setHeader("content-type", s);
 }
 
@@ -511,7 +511,7 @@ pub fn setHeader(self: *const Request, name: []const u8, value: []const u8) Http
     // FIXME without the following if, we get errors in release builds
     // at least we don't have to log unconditionally
     if (ret == -1) {
-        zap.log.debug("***************** zap.zig:274\n", .{});
+        zap.log.debug("***************** zap.zig:274", .{});
     }
 
     if (ret == 0) return;
@@ -680,7 +680,7 @@ pub fn setCookie(self: *const Request, args: CookieArgs) HttpError!void {
     // TODO: still happening?
     const ret = fio.http_set_cookie(self.h, c);
     if (ret == -1) {
-        zap.log.err("fio.http_set_cookie returned: {}\n", .{ret});
+        zap.log.err("fio.http_set_cookie returned: {}", .{ret});
         return error.SetCookie;
     }
 }


### PR DESCRIPTION
From this example:

```
debug(request): /notavideofile
error(process): /home/joey/MultiMedia/notavideofile: error.FFmpegFailure (after 47.208ms)
debug(zap): setting content-type to application/json

debug(request): /video.mp4
```

Zap was adding an additional newline to the log lines now that Zig's standard logging facilities are used. It was quite inconsistent, too.