### PR TITLE
fix build error for example/app/basic

### DIFF
--- a/examples/app/basic.zig
+++ b/examples/app/basic.zig
@@ -88,6 +88,7 @@ const StopEndpoint = struct {
     pub fn delete(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn patch(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
     pub fn options(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
+    pub fn head(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 pub fn main() !void {


### PR DESCRIPTION
Fix build error `zig build app_basic`:
```
rc/App.zig:120:53: error: no field or member function named 'head' in 'basic.StopEndpoint'
                            .HEAD => self.endpoint.*.head(arena, app_context, r),
                                     ~~~~~~~~~~~~~~~^~~~~
```
