### PR TITLE
Provide defaults to unimplemented methods in endpoints for App style api.

### DIFF
--- a/examples/app/auth.zig
+++ b/examples/app/auth.zig
@@ -58,14 +58,6 @@ const MyEndpoint = struct {
         );
         try r.sendBody(response);
     }
-
-    // not implemented, don't care
-    pub fn post(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn put(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn delete(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn patch(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn options(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn head(_: *MyEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 pub fn main() !void {
@@ -83,8 +75,8 @@ pub fn main() !void {
     // App is the type
     // app is the instance
     const App = zap.App.Create(MyContext);
-    var app = try App.init(allocator, &my_context, .{});
-    defer app.deinit();
+    try App.init(allocator, &my_context, .{});
+    defer App.deinit();
 
     // create mini endpoint
     var ep: MyEndpoint = .{
@@ -101,10 +93,10 @@ pub fn main() !void {
     var auth_ep = BearerAuthEndpoint.init(&ep, &authenticator);
 
     // make the authenticating endpoint known to the app
-    try app.register(&auth_ep);
+    try App.register(&auth_ep);
 
     // listen
-    try app.listen(.{
+    try App.listen(.{
         .interface = "0.0.0.0",
         .port = 3000,
     });

--- a/examples/app/basic.zig
+++ b/examples/app/basic.zig
@@ -59,15 +59,7 @@ const SimpleEndpoint = struct {
         try r.sendBody(response_text);
         std.time.sleep(std.time.ns_per_ms * 300);
     }
-
-    // empty stubs for all other request methods
-    pub fn post(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn put(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn delete(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn patch(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn options(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn head(_: *SimpleEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-};
+ };
 
 const StopEndpoint = struct {
     path: []const u8,
@@ -82,12 +74,6 @@ const StopEndpoint = struct {
         , .{context.*.db_connection});
         zap.stop();
     }
-
-    pub fn post(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn put(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn delete(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn patch(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
-    pub fn options(_: *StopEndpoint, _: Allocator, _: *MyContext, _: zap.Request) !void {}
 };
 
 pub fn main() !void {
@@ -104,19 +90,19 @@ pub fn main() !void {
 
     // create an App instance
     const App = zap.App.Create(MyContext);
-    var app = try App.init(allocator, &my_context, .{});
-    defer app.deinit();
+    try App.init(allocator, &my_context, .{});
+    defer App.deinit();
 
     // create the endpoints
     var my_endpoint = SimpleEndpoint.init("/test", "some endpoint specific data");
     var stop_endpoint: StopEndpoint = .{ .path = "/stop" };
     //
-    // register the endpoints with the app
-    try app.register(&my_endpoint);
-    try app.register(&stop_endpoint);
+    // register the endpoints with the App
+    try App.register(&my_endpoint);
+    try App.register(&stop_endpoint);
 
     // listen on the network
-    try app.listen(.{
+    try App.listen(.{
         .interface = "0.0.0.0",
         .port = 3000,
     });

--- a/examples/app/errors.zig
+++ b/examples/app/errors.zig
@@ -86,24 +86,24 @@ pub fn main() !void {
     defer std.debug.print("\n\nLeaks detected: {}\n\n", .{gpa.deinit() != .ok});
     const allocator = gpa.allocator();
 
-    // create an app context
+    // create an App context
     var my_context: MyContext = .{ .db_connection = "db connection established!" };
 
     // create an App instance
     const App = zap.App.Create(MyContext);
-    var app = try App.init(allocator, &my_context, .{});
-    defer app.deinit();
+    try App.init(allocator, &my_context, .{});
+    defer App.deinit();
 
     // create the endpoints
     var my_endpoint = ErrorEndpoint.init("/error", "some endpoint specific data");
     var stop_endpoint: StopEndpoint = .{ .path = "/stop" };
     //
-    // register the endpoints with the app
-    try app.register(&my_endpoint);
-    try app.register(&stop_endpoint);
+    // register the endpoints with the App
+    try App.register(&my_endpoint);
+    try App.register(&stop_endpoint);
 
     // listen on the network
-    try app.listen(.{
+    try App.listen(.{
         .interface = "0.0.0.0",
         .port = 3000,
     });


### PR DESCRIPTION
Make `get`, `post`, ... methods optional in endpoint. Check whether these method exist at comptime. When no corresponding method is provided, the handler simply return immediately.

Since it uses comptime, hopefully it should not add any checks at runtime.

Also since App shares a global state (`_static`), I think it makes more sense NOT accept an `app` instance in the apis. So:

old:
```zig
var app = App.init(...);
try app.register(...);
```

proposal:
```
App.init(...);
App.register(...);
```

See `examples/app/`.
