### PR TITLE
feat: add parition support for cookies in facil.io

### DIFF
--- a/facil.io/lib/facil/http/http.c
+++ b/facil.io/lib/facil/http/http.c
@@ -320,6 +320,9 @@ int http_set_cookie(http_s *h, http_cookie_args_s cookie) {
   if (cookie.secure) {
     fiobj_str_write(c, "secure;", 7);
   }
+  if(cookie.partitioned) {
+    fiobj_str_write(c, "Partitioned;", 12);
+  }
   set_header_add(h->private_data.out_headers, HTTP_HEADER_SET_COOKIE, c);
   return 0;
 }

--- a/facil.io/lib/facil/http/http.h
+++ b/facil.io/lib/facil/http/http.h
@@ -153,6 +153,8 @@ typedef struct {
   unsigned secure : 1;
   /** Limit cookie to HTTP (intended to prevent javascript access/hijacking).*/
   unsigned http_only : 1;
+  /** Partitioned storage, with a separate cookie jar per top-level site */
+  unsigned partitioned: 1;
 } http_cookie_args_s;
 
 /**

--- a/src/fio.zig
+++ b/src/fio.zig
@@ -116,6 +116,7 @@ pub const http_cookie_args_s = extern struct {
     max_age: c_int,
     secure: c_uint,
     http_only: c_uint,
+    partitioned: c_uint,
 };
 
 pub const struct_fio_str_info_s = extern struct {

--- a/src/request.zig
+++ b/src/request.zig
@@ -273,6 +273,7 @@ pub const CookieArgs = struct {
     max_age_s: c_int = 0,
     secure: bool = true,
     http_only: bool = true,
+    partitioned: bool = false,
 };
 
 path: ?[]const u8,
@@ -683,6 +684,7 @@ pub fn setCookie(self: *const Request, args: CookieArgs) HttpError!void {
         .max_age = args.max_age_s,
         .secure = if (args.secure) 1 else 0,
         .http_only = if (args.http_only) 1 else 0,
+        .partitioned = if (args.partitioned) 1 else 0,
     };
 
     // TODO WAT?


### PR DESCRIPTION
my app is going to run in an iframe so I think i need this partitioned flag attached to the cookie.

https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies