### PR TITLE
examples/hello2: serve HTML instead of triggering a download

### DIFF
--- a/examples/hello2/hello2.zig
+++ b/examples/hello2/hello2.zig
@@ -26,7 +26,7 @@ fn on_request(r: zap.Request) !void {
         std.debug.print(">> BODY: {s}\n", .{the_body});
     }
 
-    try r.setContentTypeFromPath();
+    try r.setContentType(.HTML);
     try r.sendBody(
         \\ <html><body>
         \\   <h1>Hello from ZAP!!!</h1>


### PR DESCRIPTION
## Problem

Running `zig build run-hello2` and opening http://localhost:3000 in a browser downloads the response as a file instead of rendering the page.

## Cause

The handler calls `r.setContentTypeFromPath()`, which derives the `Content-Type` from the request path's file extension. The root URL `/` has no extension, so the response gets a generic (octet-stream–like) type and browsers download it rather than rendering it.

## Fix

The handler always returns an HTML page regardless of path, so set the content type explicitly with `r.setContentType(.HTML)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)